### PR TITLE
Fix for SAI airport IATA code

### DIFF
--- a/lib/world_airports/scrapper/scrapped_2.rb
+++ b/lib/world_airports/scrapper/scrapped_2.rb
@@ -2480,7 +2480,6 @@ def airp_2
    :icao=>"VYSW",
    :city=>"Sittwe",
    :country=>"Myanmar (Burma)", :country_code=>'MM',
-   :country_code=> "MM",
    :location=>"Sittwe, Myanmar (Burma)"},
  "AAW"=>
   {:iata=>"AAW",

--- a/lib/world_airports/scrapper/scrapped_20.rb
+++ b/lib/world_airports/scrapper/scrapped_20.rb
@@ -2256,7 +2256,7 @@ def airp_20
    :icao=>"VDSA",
    :city=>"Siem Reap",
    :country=>'Cambodia', :country_code=>'KH',
-   :location=>"Sotr Nikum, Siem Reap, Cambodia"},
+   :location=>"Siem Reap, Cambodia"},
  "SLD"=>
   {:iata=>"SLD",
    :name=>"Sliač Airport",

--- a/lib/world_airports/scrapper/scrapped_20.rb
+++ b/lib/world_airports/scrapper/scrapped_20.rb
@@ -2252,11 +2252,11 @@ def airp_20
    :location=>"Strezhevoy, Tomsk Oblast, Russia"},
  "SAI"=>
   {:iata=>"SAI",
-   :name=>"San Marino Airport",
-   :icao=>"",
-   :city=>"San Marino",
-   :country=>'Republic of San Marino', :country_code=>'SM',
-   :location=>"San Marino, Republic of San Marino"},
+   :name=>"Siem Reap–Angkor International Airport",
+   :icao=>"VDSA",
+   :city=>"Siem Reap",
+   :country=>'Cambodia', :country_code=>'KH',
+   :location=>"Sotr Nikum, Siem Reap, Cambodia"},
  "SLD"=>
   {:iata=>"SLD",
    :name=>"Sliač Airport",


### PR DESCRIPTION
This commit fixes the information for airport with iata code SAI, which contains information of another airport.

SAI iata code was updated with information sourced here: https://en.wikipedia.org/wiki/Siem_Reap%E2%80%93Angkor_International_Airport

I have checked and the information that was populated in SAI belongs to RMI, which is correct. Source: https://en.wikipedia.org/wiki/Federico_Fellini_International_Airport